### PR TITLE
Import anarci lazily so kasearch can be imported without it

### DIFF
--- a/kasearch/anarci_numbering.py
+++ b/kasearch/anarci_numbering.py
@@ -1,8 +1,10 @@
-from anarci import anarci
 from multiprocessing import Pool
 from functools import partial
 
 def _number_chunk(sequences, scheme="imgt", database="ALL", allow=set(["H","K","L"]), allowed_species=['human','mouse'], strict = True, **kwargs):
+    # Imported lazily so `import kasearch` does not require anarci (which depends on the CC-licensed IMGT
+    # germline database). Only needed when KA-Search's own ANARCI numbering path is actually used.
+    from anarci import anarci
     try:
         numbered, _, _ = anarci(list(enumerate(sequences)), scheme=scheme, database=database, allow=allow, allowed_species=allowed_species, **kwargs)
         numbered  = [x[0][0] if x else None for x in numbered]


### PR DESCRIPTION
anarci depends on the CC-licensed IMGT germline database, which makes it unsuitable for commercial use. Move the top-level `from anarci import anarci` into _number_chunk (the only place it is used) so `import kasearch` succeeds without anarci installed; it is only required if KA-Search's own ANARCI numbering path is actually called. We are using immunum instead of anarci, which has a more permissive licence - if interested, I can create a pull request to replace anarci with immunum or add it as an alternative.